### PR TITLE
fix: 修复Shamrock发送链接图片问题

### DIFF
--- a/adapter/shamrock/sendMsg.js
+++ b/adapter/shamrock/sendMsg.js
@@ -134,7 +134,7 @@ export default class SendMsg {
         }
         /** url图片 */
         else if (/^http(s)?:\/\//.test(file)) {
-            return { type: "image", data: { url: file } }
+            return { type: "image", data: { file, url: file } }
         }
         /** 留个容错防止炸了 */
         else {


### PR DESCRIPTION
发送链接类型的图片时，会提示不支持查看，例如憨憨插件。
![image](https://github.com/Zyy955/Lain-plugin/assets/21212372/d8eaa971-440d-4084-8491-e1fddf037da9)
shamrock端日志如下：
![image](https://github.com/Zyy955/Lain-plugin/assets/21212372/2b463d19-0e04-4140-bce8-d4efb7f920fc)
查阅[文档](https://whitechi73.github.io/OpenShamrock/message/media.html#%E5%8F%82%E6%95%B0)是说file是必填项，尝试将链接传入file后正常。保留了可选的url字段。
