### PR TITLE
fix: 更新shamrock历史聊天记录api

### DIFF
--- a/adapter/shamrock/api.js
+++ b/adapter/shamrock/api.js
@@ -474,9 +474,10 @@ let api = {
      * @param {number} user_id - 私聊QQ
      * @param {number} group_id - 群号
      * @param {number} count - 获取的消息数量（默认为20）
+     * @param {number} message_seq - 起始消息的message_id（默认为0，表示从最后一条发言往前）
      */
-    async get_history_msg(id, message_type, user_id, group_id, count) {
-        const params = { message_type, user_id, group_id, count }
+    async get_history_msg(id, message_type, user_id, group_id, count, message_seq) {
+        const params = { message_type, user_id, group_id, count, message_seq }
         return await this.SendApi(id, "get_history_msg", params)
     },
 
@@ -485,9 +486,10 @@ let api = {
      * @param {string} id - 机器人QQ
      * @param {number} group_id - 群号
      * @param {number} count - 获取的消息数量（默认为20）
+     * @param {number} message_seq - 起始消息的message_id（默认为0，表示从最后一条发言往前）
      */
-    async get_group_msg_history(id, group_id, count) {
-        const params = { group_id, count }
+    async get_group_msg_history(id, group_id, count, message_seq) {
+        const params = { group_id, count, message_seq }
         return await this.SendApi(id, "get_group_msg_history", params)
     },
 

--- a/adapter/shamrock/bot.js
+++ b/adapter/shamrock/bot.js
@@ -80,14 +80,14 @@ export default new class addBot {
                         return await api.set_group_kick(uin, groupID, qq, reject_add_request)
                     },
                     /**
-                     * shamrock目前只支持从当前往前数，所以msg_id实际未使用
-                     * @param msg_id 当前无用
+                     * 获取聊天历史记录
+                     * @param msg_id 起始消息的message_id（默认为0，表示从最后一条发言往前）
                      * @param num 数量
                      * @param reply 是否展开回复引用的消息(source)（实测数量大的时候耗时且可能出错）
                      * @return {Promise<Awaited<unknown>[]>}
                      */
                     getChatHistory: async (msg_id, num, reply) => {
-                        let { messages } = await api.get_group_msg_history(uin, groupID, num)
+                        let { messages } = await api.get_group_msg_history(uin, groupID, num, msg_id)
                         let group = Bot[uin].gl.get(groupID)
                         messages = messages.map(async m => {
                             m.group_name = group?.group_name || groupID
@@ -119,14 +119,14 @@ export default new class addBot {
                         return await common.makeForwardMsg(forwardMsg)
                     },
                     /**
-                     * shamrock目前只支持从当前往前数，所以msg_id实际未使用
-                     * @param msg_id 当前无用
+                     * 获取私聊聊天记录
+                     * @param msg_id 起始消息的message_id（默认为0，表示从最后一条发言往前）
                      * @param num 数量
                      * @param reply 是否展开回复引用的消息(source)（实测数量大的时候耗时且可能出错）
                      * @return {Promise<Awaited<unknown>[]>}
                      */
                     getChatHistory: async (msg_id, num, reply) => {
-                        let { messages } = await api.get_history_msg(uin, "private", user_id, null, num)
+                        let { messages } = await api.get_history_msg(uin, "private", user_id, null, num, msg_id)
                         messages = messages.map(async m => {
                             m.raw_message = toRaw(m.message, uin)
                             let result = await message(uin, m.message, null, reply)
@@ -163,14 +163,14 @@ export default new class addBot {
                         return await common.makeForwardMsg(forwardMsg)
                     },
                     /**
-                     * shamrock目前只支持从当前往前数，所以msg_id实际未使用
-                     * @param msg_id 当前无用
+                     * 获取私聊聊天记录
+                     * @param msg_id 起始消息的message_id（默认为0，表示从最后一条发言往前）
                      * @param num 数量
                      * @param reply 是否展开回复引用的消息(source)（实测数量大的时候耗时且可能出错）
                      * @return {Promise<Awaited<unknown>[]>}
                      */
                     getChatHistory: async (msg_id, num, reply) => {
-                        let { messages } = await api.get_history_msg(uin, "private", user_id, null, num)
+                        let { messages } = await api.get_history_msg(uin, "private", user_id, null, num, msg_id)
                         messages = messages.map(async m => {
                             m.raw_message = toRaw(m.message, uin)
                             let result = await message(uin, m.message, null, reply)

--- a/adapter/shamrock/message.js
+++ b/adapter/shamrock/message.js
@@ -110,10 +110,9 @@ export default new class zaiMsg {
                         getAvatarUrl: (userId = id) => `https://q1.qlogo.cn/g?b=qq&s=0&nk=${userId}`
                     }
                 },
-                // shamrock目前只支持从当前往前数，所以msg_id实际未使用
                 getChatHistory: async (msg_id, num, reply) => {
                     try {
-                        let { messages } = await api.get_group_msg_history(self_id, group_id, num)
+                        let { messages } = await api.get_group_msg_history(self_id, group_id, num, msg_id)
                         messages = messages.map(async m => {
                             m.group_name = group_name
                             m.atme = !!m.message.find(msg => msg.type === "at" && msg.data?.qq == self_id)
@@ -207,7 +206,7 @@ export default new class zaiMsg {
                 },
                 getChatHistory: async (msg_id, num, reply = true) => {
                     try {
-                        let messages = await api.get_history_msg(self_id, "private", user_id, null, num)
+                        let messages = await api.get_history_msg(self_id, "private", user_id, null, num, msg_id)
                         messages = messages.map(async m => {
                             m.raw_message = toRaw(m.message, self_id, group_id)
                             let result = await this.message(self_id, m.message, null, reply)


### PR DESCRIPTION
支持shamrock的message_seq，应该能让一些引用类的命令正常使用了